### PR TITLE
Adds margin to pricing page's header

### DIFF
--- a/app/styles/pricing/header.module.css
+++ b/app/styles/pricing/header.module.css
@@ -69,10 +69,10 @@
     }
 }
 
-
 @media screen and (max-width: 768px) {
     .text > h1 {
         margin-bottom: 20px;
+        margin-top: 50px;
     }
 
     .header {
@@ -95,7 +95,6 @@
         padding: 4.438rem;
     }
 }
-
 
 @media screen and (max-width: 480px) {
     .text > h1 {


### PR DESCRIPTION
Adds margin to the top of the pricing page's heading.

## Before


<img src="https://github.com/user-attachments/assets/10ef6f4a-f4e3-4ef8-a866-560e63cd85c6" width='500px'/>








## After

<img src="https://github.com/user-attachments/assets/9ad5666d-c9df-4d1d-84fa-6524d9b8cda9" width='500px'/>

